### PR TITLE
Improve and fix application helper tests

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -31,21 +31,31 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe '#list_group_item' do
     before :each do
-      @item = helper.nav_entry('test', 'http://google.com')
+      @item = helper.list_group_item('test', 'http://google.com')
+      @count = 1
+      @count2 = 0
     end
 
     it 'should return a content tag' do
-      expect(@item).to include('<li')
+      expect(@item).to include('<a')
       expect(@item).to include('http://google.com')
       expect(@item).to include('test')
     end
 
     it 'should return a badge if specified' do
-      @item2 = helper.nav_entry('test', 'http://google.com', {
-        badge: true,
+      @item = helper.list_group_item('test', 'http://google.com', {
+        badge: @count,
         badge_color: 'rainbow'
       })
-      expect(@item2).to include('badge-rainbow')
+      expect(@item).to include('badge-rainbow')
+    end
+
+    it 'should not return a badge if the count is 0' do
+      @item = helper.list_group_item('test', 'http://google.com', {
+        badge: @count2,
+        badge_color: 'rainbow'
+      })
+      expect(@item).to_not include('badge-rainbow')
     end
   end
 


### PR DESCRIPTION
I looked over the application helper tests and saw that they were copy & paste with the `nav_entry` function, which never covered `list_group_item` functions.

This is now fixed and all tests should pass now.